### PR TITLE
Fix/fix widget mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,22 +7,20 @@ This library contemplate that an iframe with the ID: soyio-widget-iframe should 
 
 For frontend frameworks, this should be imported as follows.
 
-``` VUE
+``` html
 <script>
-import Widget from '@soyio/soyio-widget'
-
-// Vue syntax
-onMounted(() => {
-  const widget = new Widget()
-})
+// insert setup of your framework here!! 
+document.addEventListener('DOMContentLoaded', function() {
+  new Widget({ userEmail: 'example@email.com'})
+});
 </script>
-<template>
+<body>
   <iframe id="soyio-widget-iframe"></iframe>
-</template>
+</body>
 
 ```
 
-The widget class receive the following object:
+The widget class receive the following object when is initialized:
 
 ```JS
 {

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # soy-io-widget
 This is the library for include a soyio widget.
 
-This library contemplate that an iframe with the ID: soyio-widget-iframe should be created before instantiate the widget.
+This library contemplate that a div element with ID: `soyio-widget-iframe-container` should be created before instantiate the widget.
 
 ## How to work
 
@@ -15,7 +15,7 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 </script>
 <body>
-  <iframe id="soyio-widget-iframe"></iframe>
+  <div id="soyio-widget-iframe-container"></div>
 </body>
 
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soyio/soyio-widget",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "module",
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",

--- a/spec/widget.spec.ts
+++ b/spec/widget.spec.ts
@@ -1,22 +1,22 @@
 import { it, expect, describe, beforeEach } from 'vitest';
 import { mountIframeToDOM } from '../src/widget';
-import { DEVELOPMENT_WIDGET_URL, IFRAME_ID } from '../src/constants';
+import { DEVELOPMENT_WIDGET_URL, CONTAINER_ID } from '../src/constants';
 
 describe('widget', () => {
-  describe('when iframe does not exists', () => {
+  describe('when div does not exists', () => {
     beforeEach(() => {
       document.body.innerHTML = '';
     });
     it('Throw error', () => {
-      expect(() => mountIframeToDOM()).toThrowError('Iframe does not exist');
+      expect(() => mountIframeToDOM()).toThrowError('Iframe container does not exist');
     });
   });
 
-  describe('when iframe exists', () => {
+  describe('when div exists', () => {
     beforeEach(() => {
-      document.body.innerHTML = `<iframe id="${IFRAME_ID}"></iframe>`;
+      document.body.innerHTML = `<div id="${CONTAINER_ID}"></div>`;
     });
-    it('does not mount iframe', () => {
+    it('does mount iframe', () => {
       mountIframeToDOM();
       const createdIframes = document.querySelectorAll('iframe');
       expect(createdIframes.length).toBe(1);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,2 @@
-export const IFRAME_ID = 'soyio-widget-iframe';
+export const CONTAINER_ID = 'soyio-widget-iframe-container';
 export const DEVELOPMENT_WIDGET_URL = 'https://pl-soyio-staging-7a391ba45b99.herokuapp.com/widget';

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -1,17 +1,20 @@
-import { IFRAME_ID, DEVELOPMENT_WIDGET_URL } from './constants';
+import { CONTAINER_ID, DEVELOPMENT_WIDGET_URL } from './constants';
 
 const WIDGET_URL = DEVELOPMENT_WIDGET_URL;
 
-function getIframe(): HTMLIFrameElement | undefined {
-  return document.getElementById(IFRAME_ID) as HTMLIFrameElement | undefined;
+function getIframeContainer(): HTMLDivElement | undefined {
+  return document.getElementById(CONTAINER_ID) as HTMLDivElement | undefined;
 }
 
 export function mountIframeToDOM(): HTMLIFrameElement {
-  const iframe = getIframe();
-  if (!iframe) {
-    throw new Error('Iframe does not exist');
+  const iframeContainer = getIframeContainer();
+  if (!iframeContainer) {
+    throw new Error('Iframe container does not exist');
   }
+
+  const iframe = document.createElement('iframe');
   iframe.src = WIDGET_URL;
+  iframeContainer.appendChild(iframe);
 
   return iframe;
 }


### PR DESCRIPTION
## Context

Soyio is making a library to be able to be connected with their app.
Previously, it was needed an `iframe` element to mount the widget.

## What has been doing?

Now, to mount the `iframe` widget, it is necessary to have a `div` element with ID: `soyio-widget-iframe-container`