### PR TITLE
fix(Style): fix widget dimensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soyio/soyio-widget",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "module",
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -14,6 +14,8 @@ export function mountIframeToDOM(): HTMLIFrameElement {
 
   const iframe = document.createElement('iframe');
   iframe.src = WIDGET_URL;
+  iframe.style.width = '100%';
+  iframe.style.height = '100%';
   iframeContainer.appendChild(iframe);
 
   return iframe;


### PR DESCRIPTION
## Context

Soyio is developing a library that enables integration with their application.
Until recently, the widget did not automatically adjust its size to match that of the `iframe-container`. This limitation prevented users from resizing the widget, often resulting in it appearing too small.

## What has been doing?

The width and height of the widget will now use 100% of the father component dimensions.