### PR TITLE
Fix existing iframe

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soyio/soyio-widget",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "type": "module",
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,3 @@
 export const CONTAINER_ID = 'soyio-widget-iframe-container';
+export const IFRAME_ID = 'soyio-widget-iframe';
 export const DEVELOPMENT_WIDGET_URL = 'https://pl-soyio-staging-7a391ba45b99.herokuapp.com/widget';

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -1,12 +1,17 @@
-import { CONTAINER_ID, DEVELOPMENT_WIDGET_URL } from './constants';
+import { CONTAINER_ID, IFRAME_ID, DEVELOPMENT_WIDGET_URL } from './constants';
 
 const WIDGET_URL = DEVELOPMENT_WIDGET_URL;
+
+function iframeExists(): boolean {
+  return !!document.getElementById(IFRAME_ID);
+}
 
 function getIframeContainer(): HTMLDivElement | undefined {
   return document.getElementById(CONTAINER_ID) as HTMLDivElement | undefined;
 }
 
-export function mountIframeToDOM(): HTMLIFrameElement {
+// eslint-disable-next-line max-statements
+function mountIframe(): HTMLIFrameElement {
   const iframeContainer = getIframeContainer();
   if (!iframeContainer) {
     throw new Error('Iframe container does not exist');
@@ -14,9 +19,19 @@ export function mountIframeToDOM(): HTMLIFrameElement {
 
   const iframe = document.createElement('iframe');
   iframe.src = WIDGET_URL;
+  iframe.id = IFRAME_ID;
+  iframe.style.zIndex = String(Number.MAX_SAFE_INTEGER);
   iframe.style.width = '100%';
   iframe.style.height = '100%';
   iframeContainer.appendChild(iframe);
 
   return iframe;
+}
+
+export function mountIframeToDOM(): HTMLIFrameElement {
+  if (!iframeExists()) {
+    return mountIframe();
+  }
+
+  return document.getElementById(IFRAME_ID) as HTMLIFrameElement;
 }


### PR DESCRIPTION
## Context

Soyio is developing a library that enables integration with their application.

Previously, our widget implementation lacked a mechanism to verify the existence of an iframe instance before attempting to mount a new one. This oversight could potentially lead to redundant iframe creations, affecting performance and the overall user experience.

## What has been doing?

In our latest update, we've introduced a significant improvement to address this issue. The widget now includes a check for an existing iframe with the `id` set to `soyio-widget-iframe`. If such an iframe already exists, the widget will forego creating a new instance and instead return the existing iframe HTML object.